### PR TITLE
Fix incomplete list of reserved fact symbols in the syntax description

### DIFF
--- a/src/016_syntax_description.md
+++ b/src/016_syntax_description.md
@@ -214,7 +214,7 @@ the function definition.
 
 Facts do not have to be defined up-front. This will probably change once we
 implement user-defined sorts. Facts prefixed with `!` are persistent facts.
-All other facts are linear. There are six reserved fact symbols: In, Out, KU,
+All other facts are linear. There are six reserved fact symbols: In, Out, Fr, KU,
 KD, and K. KU and KD facts are used for construction and deconstruction
 rules. KU-facts also log the messages deduced by construction rules. Note that
 KU-facts have arity 2. Their first argument is used to track the


### PR DESCRIPTION

Hi!

I was reading through the manual when I noticed the following small mistake.
In the "Syntax Description" chapter, the sentence "There are six reserved fact symbols: In, Out, KU, KD, and K." doesn't list "Fr" as a reserved fact symbol. So, I added it.